### PR TITLE
Update Checkout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ inputs.token }}


### PR DESCRIPTION
Bumps actions/checkout to the latest version, as 3 is deprecated.